### PR TITLE
Add missing npm package dependencies to `.vscodeignore`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,4 +18,8 @@ client/node_modules/**
 !client/node_modules/vscode-languageclient/**
 !client/node_modules/vscode-languageserver-protocol/**
 !client/node_modules/vscode-languageserver-types/**
+!client/node_modules/brace-expansion/**
+!client/node_modules/balanced-match/**
+!client/node_modules/lru-cache/**
+!client/node_modules/yallist/**
 !client/node_modules/semver/**


### PR DESCRIPTION
First of all, thanks for this great extension!      

The Stimulus LSP wouldn't worked for me when installing the package through the VS Code extensions marketplace.   
Running the extension locally worked just fine.   
After some debugging I found the following error message in the VS Code developer tools:   
(I get the error message directly after installing or after opening a *.html.erb file for the first time)     
![image](https://github.com/marcoroth/stimulus-lsp/assets/17851143/637dc622-42ed-45d3-b99f-ffa281ad689e)      


I had to add 4 npm dependencies to `.vscodeignore` before it worked for me.   
I'm not 100% sure if this is the right way...
