### PR TITLE
Fix diagnostics for camelized Stimulus Value names

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -105,27 +105,27 @@ export class Diagnostics {
         if (!controller) {
           const identifierSplits = identifier.split("--")
 
-          let potentialValuePart
-          let identifierNamespace
+          let valuePart
+          let namespacePart
 
           // has namespace
           if (identifierSplits.length > 1) {
-            identifierNamespace = identifierSplits.slice(0, -1).join("--")
-            potentialValuePart = identifierSplits[identifierSplits.length - 1]
+            namespacePart = identifierSplits.slice(0, -1).join("--")
+            valuePart = identifierSplits[identifierSplits.length - 1]
           } else {
-            identifierNamespace = null
-            potentialValuePart = identifierSplits[0]
+            namespacePart = null
+            valuePart = identifierSplits[0]
           }
 
-          const allParts = potentialValuePart.split("-").concat(valueName.split("-"))
+          const allParts = valuePart.split("-").concat(valueName.split("-"))
 
           for (let i = 1; i <= allParts.length; i++) {
             if (controller) continue
 
             let potentialIdentifier = allParts.slice(0, i).join("-")
 
-            if (identifierNamespace) {
-              potentialIdentifier = `${identifierNamespace}--${potentialIdentifier}`
+            if (namespacePart) {
+              potentialIdentifier = `${namespacePart}--${potentialIdentifier}`
             }
 
             const potentialValueName = allParts.slice(i, allParts.length).join("-")

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -6,7 +6,7 @@ import { parseActionDescriptorString } from "./action_descriptor"
 
 import { DocumentService } from "./document_service"
 import { attributeValue, tokenList } from "./html_util"
-import { didyoumean } from "./utils"
+import { didyoumean, camelize } from "./utils"
 import { StimulusHTMLDataProvider } from "./data_providers/stimulus_html_data_provider"
 
 export interface InvalidControllerDiagnosticData {
@@ -97,10 +97,47 @@ export class Diagnostics {
       // TODO: skip when value contains <%= or %>
 
       if (attributeMatches && Array.isArray(attributeMatches) && attributeMatches[1]) {
-        const identifier = attributeMatches[1]
-        const valueName = attributeMatches[2]
+        let identifier = attributeMatches[1]
+        let valueName = attributeMatches[2]
 
-        const controller = this.controllers.find((controller) => controller.identifier === identifier)
+        let controller = this.controllers.find((controller) => controller.identifier === identifier)
+
+        if (!controller) {
+          const identifierSplits = identifier.split("--")
+
+          let potentialValuePart
+          let identifierNamespace
+
+          // has namespace
+          if (identifierSplits.length > 1) {
+            identifierNamespace = identifierSplits.slice(0, -1).join("--")
+            potentialValuePart = identifierSplits[identifierSplits.length - 1]
+          } else {
+            identifierNamespace = null
+            potentialValuePart = identifierSplits[0]
+          }
+
+          const allParts = potentialValuePart.split("-").concat(valueName.split("-"))
+
+          for (let i = 1; i <= allParts.length; i++) {
+            if (controller) continue
+
+            let potentialIdentifier = allParts.slice(0, i).join("-")
+
+            if (identifierNamespace) {
+              potentialIdentifier = `${identifierNamespace}--${potentialIdentifier}`
+            }
+
+            const potentialValueName = allParts.slice(i, allParts.length).join("-")
+
+            controller = this.controllers.find((controller) => controller.identifier === potentialIdentifier)
+
+            if (controller) {
+              identifier = potentialIdentifier
+              valueName = potentialValueName
+            }
+          }
+        }
 
         if (!controller) {
           const attributeNameRange = this.attributeNameRange(textDocument, node, attribute, identifier)
@@ -109,11 +146,17 @@ export class Diagnostics {
           return
         }
 
-        const valueDefiniton = controller.values[valueName]
+        const camelizedValueName = camelize(valueName)
+        const valueDefiniton = controller.values[camelizedValueName]
 
         if (controller && !valueDefiniton) {
           const attributeNameRange = this.attributeNameRange(textDocument, node, attribute, valueName)
-          this.createMissingValueOnControllerDiagnosticFor(identifier, valueName, textDocument, attributeNameRange)
+          this.createMissingValueOnControllerDiagnosticFor(
+            identifier,
+            camelizedValueName,
+            textDocument,
+            attributeNameRange
+          )
 
           return
         }
@@ -136,7 +179,7 @@ export class Diagnostics {
 
           this.createValueMismatchOnControllerDiagnosticFor(
             identifier,
-            valueName,
+            camelizedValueName,
             expectedType,
             actualType,
             textDocument,

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -19,3 +19,7 @@ export function didyoumean(input: string, list: string[]): string | null {
 
   return scores[0].item
 }
+
+export function camelize(value: string) {
+  return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase())
+}


### PR DESCRIPTION
Fixes #29 

For a controller like:
```js
export default class extends Controller {
  static values = {
    frameId: String
  }
}
```


It will now properly map the dasherized attribute `frame-id` to the camelized name `frameId` as it's seen it the controller. It now handles cases like:

```html
<div 
  data-controller="form"
  data-form-frame-id-value="string"
></div>
```

Including namespaced controller identifiers:

```html
<div 
  data-controller="nested--form"
  data-nested--form-frame-id-value="string"
></div>
```


