### PR TITLE
Introduce `stimulus.attribute.mismatch` diagnostic for Stimulus Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This Language Server works for HTML and ERB files. It has the following language
 * Missing controller targets (`stimulus.controller.target.missing`)
 * Missing controller values (`stimulus.controller.value.missing`)
 * Invalid action descriptions (`stimulus.action.invalid`)
+* Data attributes format mismatches (`stimulus.attribute.mismatch`)
 * Controller values type mismatches (`stimulus.controller.value.type_mismatch`)
 
 ### Quick-Fixes

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -370,9 +370,6 @@ export class Diagnostics {
     textDocument: TextDocument,
     range: Range
   ) {
-    const controller = this.controllers.find((controller) => controller.identifier === identifier)
-    const match = controller ? didyoumean(valueName, Object.keys(controller.values)) : null
-
     this.pushDiagnostic(
       `The data attribute for "${valueName}" on the "${identifier}" controller is camelCased, but should be dasherized ("${dasherize(valueName)}"). Please use dashes to separate the Stimulus data attributes.`,
       "stimulus.attribute.mismatch",

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -6,7 +6,7 @@ import { parseActionDescriptorString } from "./action_descriptor"
 
 import { DocumentService } from "./document_service"
 import { attributeValue, tokenList } from "./html_util"
-import { didyoumean, camelize } from "./utils"
+import { didyoumean, camelize, dasherize } from "./utils"
 import { StimulusHTMLDataProvider } from "./data_providers/stimulus_html_data_provider"
 
 export interface InvalidControllerDiagnosticData {
@@ -146,6 +146,20 @@ export class Diagnostics {
           return
         }
 
+        const hasUppercaseLetter = valueName.match(/[A-Z]/g)
+
+        if (hasUppercaseLetter) {
+          const attributeNameRange = this.attributeNameRange(textDocument, node, attribute, valueName)
+          this.createAttributeFormatMismatchDiagnosticFor(
+            identifier,
+            valueName,
+            textDocument,
+            attributeNameRange
+          )
+
+          return
+        }
+
         const camelizedValueName = camelize(valueName)
         const valueDefiniton = controller.values[camelizedValueName]
 
@@ -190,6 +204,10 @@ export class Diagnostics {
     })
   }
 
+  validateDataClassAttribute(_node: Node, _textDocument: TextDocument) {
+    // TODO: implemenet
+  }
+
   validateDataTargetAttribute(node: Node, textDocument: TextDocument) {
     const attributes = node.attributes || {}
 
@@ -224,6 +242,7 @@ export class Diagnostics {
     this.validateDataControllerAttribute(node, textDocument)
     this.validateDataActionAttribute(node, textDocument)
     this.validateDataValueAttribute(node, textDocument)
+    this.validateDataClassAttribute(node, textDocument)
     this.validateDataTargetAttribute(node, textDocument)
 
     node.children.forEach((child) => {
@@ -342,6 +361,24 @@ export class Diagnostics {
       range,
       textDocument,
       { identifier, actionName }
+    )
+  }
+
+  private createAttributeFormatMismatchDiagnosticFor(
+    identifier: string,
+    valueName: string,
+    textDocument: TextDocument,
+    range: Range
+  ) {
+    const controller = this.controllers.find((controller) => controller.identifier === identifier)
+    const match = controller ? didyoumean(valueName, Object.keys(controller.values)) : null
+
+    this.pushDiagnostic(
+      `The data attribute for "${valueName}" on the "${identifier}" controller is camelCased, but should be dasherized ("${dasherize(valueName)}"). Please use dashes to separate the Stimulus data attributes.`,
+      "stimulus.attribute.mismatch",
+      range,
+      textDocument,
+      { identifier, valueName }
     )
   }
 


### PR DESCRIPTION
![CleanShot 2023-10-20 at 05 52 06](https://github.com/marcoroth/stimulus-lsp/assets/6411752/24e99525-4806-48da-a200-da13771643d5)
