### PR TITLE
Support for multiple controller root folders

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
   "scripts": {},
   "dependencies": {
     "@hotwired/stimulus": "https://github.com/hotwired/dev-builds/archive/refs/tags/@hotwired/stimulus/8cbca6d.tar.gz",
-    "stimulus-parser": "^0.0.8",
+    "stimulus-parser": "^0.0.11",
     "typescript": "^5.2.2",
     "vscode-html-languageservice": "^4.0.5",
     "vscode-languageserver": "^7.0.0",

--- a/server/src/code_actions.ts
+++ b/server/src/code_actions.ts
@@ -3,11 +3,15 @@ import { CodeAction, CodeActionKind, CodeActionParams, Command } from "vscode-la
 import { DocumentService } from "./document_service"
 import { InvalidControllerDiagnosticData } from "./diagnostics"
 
+import { Project } from "stimulus-parser"
+
 export class CodeActions {
   private readonly documentService: DocumentService
+  private readonly project: Project
 
-  constructor(documentService: DocumentService) {
+  constructor(documentService: DocumentService, project: Project) {
     this.documentService = documentService
+    this.project = project
   }
 
   onCodeAction(params: CodeActionParams) {
@@ -22,15 +26,20 @@ export class CodeActions {
 
     if (diagnostics.length === 0) return undefined
 
-    return diagnostics.map((diagnostic) => {
+    return diagnostics.flatMap(diagnostic => {
       const identifier = (diagnostic.data as InvalidControllerDiagnosticData).identifier
-      const title = `Create "${identifier}" Stimulus Controller`
+      const manyRoots = this.project.controllerRoots.length > 1
 
-      return CodeAction.create(
-        title,
-        Command.create(title, "stimulus.controller.create", identifier, diagnostic),
-        CodeActionKind.QuickFix
-      )
+      return this.project.controllerRoots.map(root => {
+        const folder = `${manyRoots ? ` in "${root}/"` : ''}`
+        const title = `Create "${identifier}" Stimulus Controller${folder}`
+
+        return CodeAction.create(
+          title,
+          Command.create(title, "stimulus.controller.create", identifier, diagnostic, root),
+          CodeActionKind.QuickFix
+        )
+      })
     })
   }
 }

--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -1,23 +1,23 @@
 import { Connection, TextDocumentEdit, TextEdit, CreateFile, Range, Diagnostic } from "vscode-languageserver/node"
 
-import { Settings } from "./settings"
-import { ControllerDefinition } from "stimulus-parser"
+import { Project, ControllerDefinition } from "stimulus-parser"
 
 export class Commands {
-  private readonly settings: Settings
+  private readonly project: Project
   private readonly connection: Connection
 
-  constructor(settings: Settings, connection: Connection) {
-    this.settings = settings
+  constructor(project: Project, connection: Connection) {
+    this.project = project
     this.connection = connection
   }
 
-  async createController(identifier: string, diagnostic: Diagnostic) {
+  async createController(identifier: string, diagnostic: Diagnostic, controllerRoot: string) {
     if (identifier === undefined) return
     if (diagnostic === undefined) return
+    if (controllerRoot === undefined) controllerRoot = this.project.controllerRoot
 
     const path = ControllerDefinition.controllerPathForIdentifier(identifier)
-    const newControllerPath = `${this.settings.controllersPath}/${path}`
+    const newControllerPath = `${this.project.projectPath}/${controllerRoot}/${path}`
     const createFile: CreateFile = { kind: "create", uri: newControllerPath }
 
     await this.connection.workspace.applyEdit({ documentChanges: [createFile] })

--- a/server/src/data_providers/stimulus_html_data_provider.ts
+++ b/server/src/data_providers/stimulus_html_data_provider.ts
@@ -6,20 +6,11 @@ import { Project } from "stimulus-parser"
 import { dasherize } from "../utils"
 
 export class StimulusHTMLDataProvider implements IHTMLDataProvider {
-  private folder: string
-  private project: Project
-
-  constructor(private id: string, private projectPath: string) {
-    this.folder = this.projectPath.replace("file://", "")
-    this.project = new Project(this.folder)
+  constructor(private id: string, private project: Project) {
   }
 
   get controllers() {
     return this.project.controllerDefinitions
-  }
-
-  async refresh() {
-    await this.project.analyze()
   }
 
   isApplicable() {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -89,9 +89,9 @@ connection.onCodeAction((params) => service.codeActions.onCodeAction(params))
 connection.onExecuteCommand((params) => {
   if (params.command !== "stimulus.controller.create" || !params.arguments) return
 
-  const [identifier, diagnostic] = params.arguments as [string, Diagnostic]
+  const [identifier, diagnostic, controllerRoot] = params.arguments as [string, Diagnostic, string]
 
-  service.commands.createController(identifier, diagnostic)
+  service.commands.createController(identifier, diagnostic, controllerRoot)
 })
 
 connection.onCompletion((textDocumentPosition) => {

--- a/server/src/service.ts
+++ b/server/src/service.ts
@@ -26,8 +26,8 @@ export class Service {
     this.connection = connection
     this.settings = new Settings(params, this.connection)
     this.documentService = new DocumentService(this.connection)
-    this.codeActions = new CodeActions(this.documentService)
     this.project = new Project(this.settings.projectPath.replace("file://", ""))
+    this.codeActions = new CodeActions(this.documentService, this.project)
     this.stimulusDataProvider = new StimulusHTMLDataProvider("id", this.project)
     this.diagnostics = new Diagnostics(this.connection, this.stimulusDataProvider, this.documentService)
     this.definitions = new Definitions(this.documentService, this.stimulusDataProvider)

--- a/server/src/service.ts
+++ b/server/src/service.ts
@@ -8,6 +8,7 @@ import { Diagnostics } from "./diagnostics"
 import { Definitions } from "./definitions"
 import { Commands } from "./commands"
 import { CodeActions } from "./code_actions"
+import { Project } from "stimulus-parser"
 
 export class Service {
   connection: Connection
@@ -19,16 +20,18 @@ export class Service {
   commands: Commands
   documentService: DocumentService
   codeActions: CodeActions
+  project: Project
 
   constructor(connection: Connection, params: InitializeParams) {
     this.connection = connection
     this.settings = new Settings(params, this.connection)
     this.documentService = new DocumentService(this.connection)
     this.codeActions = new CodeActions(this.documentService)
-    this.stimulusDataProvider = new StimulusHTMLDataProvider("id", this.settings.projectPath)
+    this.project = new Project(this.settings.projectPath.replace("file://", ""))
+    this.stimulusDataProvider = new StimulusHTMLDataProvider("id", this.project)
     this.diagnostics = new Diagnostics(this.connection, this.stimulusDataProvider, this.documentService)
     this.definitions = new Definitions(this.documentService, this.stimulusDataProvider)
-    this.commands = new Commands(this.settings, this.connection)
+    this.commands = new Commands(this.project, this.connection)
 
     this.htmlLanguageService = getLanguageService({
       customDataProviders: [this.stimulusDataProvider],
@@ -36,7 +39,7 @@ export class Service {
   }
 
   async init() {
-    await this.stimulusDataProvider.refresh()
+    await this.project.analyze()
 
     // Only keep settings for open documents
     this.documentService.onDidClose((change) => {
@@ -51,7 +54,7 @@ export class Service {
   }
 
   async refresh() {
-    await this.stimulusDataProvider.refresh()
+    await this.project.analyze()
 
     this.diagnostics.refreshAllDocuments()
   }

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -42,10 +42,6 @@ export class Settings {
     return this.params.rootUri || ""
   }
 
-  get controllersPath() {
-    return `${this.projectPath}/app/javascript/controllers`
-  }
-
   getDocumentSettings(resource: string): Thenable<StimulusSettings> {
     if (!this.hasConfigurationCapability) {
       return Promise.resolve(this.globalSettings)

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -224,10 +224,10 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-stimulus-parser@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/stimulus-parser/-/stimulus-parser-0.0.8.tgz#b087b14fb35a759aeefe756d3d49dfaa17535ca3"
-  integrity sha512-5VU3/Y11zVCbUHBqwUQtHIT9QVIBKx2l1bWp5YFHXoXRtP1HbkFM7xLrgyJCIxQx+1MNtfUMmApINz+9rm5zWQ==
+stimulus-parser@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/stimulus-parser/-/stimulus-parser-0.0.11.tgz#7106f7ec6f8fe8657c7a6e8662334a1565104bc3"
+  integrity sha512-8FmA5kBpQLQ+xyxih+5h3dBzKqQ7sGiExguZ1MIL2ZLATvEFYleblFGJPdHQwDpVCm3fnFKWC7wOdttZQuIssQ==
   dependencies:
     "@hotwired/stimulus-webpack-helpers" "^1.0.1"
     acorn "^8.8.2"


### PR DESCRIPTION
This pull request adds support for handling multiple controller root folders. This is useful when a project has more than one folder where it defines Stimulus controllers.

Previously any controller which wasn't located in `app/javascript/controllers/` wouldn't be provided with the right identifier. For example a controller in `app/packs/controllers/test_controller.js` would have been provided as `app--packs--controllers--test` which obviously isn't right. This is now fixed and will be correctly provided as `test`.

The `stimulus-parser` now automatically detects these root folders and doesn't rely on the hard-coded `app/javascript/controllers/` folder.

Additionally the `stimulus.controller.create` Quick-Fix action now also accounts for multiple root folders. If the project has more than one root it will prompt you to choose a root folder location:
![CleanShot 2023-10-20 at 08 12 40](https://github.com/marcoroth/stimulus-lsp/assets/6411752/4308d884-b330-4b94-8b18-46b4fd7583eb)

This might fix #26.