### PR TITLE
Add diagnostic when controller can't be parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently, this Language Server only works for HTML, though its utility extends 
 * Invalid action descriptors (`stimulus.action.invalid`)
 * Data attributes format mismatches (`stimulus.attribute.mismatch`)
 * Controller values type mismatches (`stimulus.controller.value.type_mismatch`)
+* Controller parsing errors (`stimulus.controller.parse_error`)
 
 ### Quick-Fixes
 

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -46,16 +46,14 @@ export class Diagnostics {
 
   validateParsedControllerWithoutErrors(node: Node, textDocument: TextDocument) {
     const identifiers = tokenList(node, this.controllerAttribute)
-    const failedIdentifiers = identifiers.filter((identifier) => {
+
+    identifiers.forEach((identifier) => {
       const controller = this.controllers.find((controller) => controller.identifier === identifier)
 
-      return controller && controller.parseError !== undefined
-    })
+      if (!controller || controller.parseError === undefined) return
 
-    failedIdentifiers.forEach((identifier) => {
       const attributeValueRange = this.attributeValueRange(textDocument, node, this.controllerAttribute, identifier)
-
-      this.createParseErrorDiagnosticFor(identifier, textDocument, attributeValueRange)
+      this.createParseErrorDiagnosticFor(identifier, controller.parseError, textDocument, attributeValueRange)
     })
   }
 
@@ -346,9 +344,9 @@ export class Diagnostics {
     return Range.create(textDocument.positionAt(attributeValueStart), textDocument.positionAt(attributeValueEnd))
   }
 
-  private createParseErrorDiagnosticFor(identifier: string, textDocument: TextDocument, range: Range) {
+  private createParseErrorDiagnosticFor(identifier: string, error: string, textDocument: TextDocument, range: Range) {
     this.pushDiagnostic(
-      `There was an error parsing the "${identifier}" Stimulus controller. Please check the controller for syntax errors.`,
+      `There was an error parsing the "${identifier}" Stimulus controller. Please check the controller for the following error: ${error}`,
       "stimulus.controller.parse_error",
       range,
       textDocument,

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -44,6 +44,21 @@ export class Diagnostics {
     return this.controllers.map((controller) => controller.identifier)
   }
 
+  validateParsedControllerWithoutErrors(node: Node, textDocument: TextDocument) {
+    const identifiers = tokenList(node, this.controllerAttribute)
+    const failedIdentifiers = identifiers.filter((identifier) => {
+      const controller = this.controllers.find((controller) => controller.identifier === identifier)
+
+      return controller && controller.parseError !== undefined
+    })
+
+    failedIdentifiers.forEach((identifier) => {
+      const attributeValueRange = this.attributeValueRange(textDocument, node, this.controllerAttribute, identifier)
+
+      this.createParseErrorDiagnosticFor(identifier, textDocument, attributeValueRange)
+    })
+  }
+
   validateDataControllerAttribute(node: Node, textDocument: TextDocument) {
     const identifiers = tokenList(node, this.controllerAttribute)
     const invalidIdentifiers = identifiers.filter((identifier) => !this.controllerIdentifiers.includes(identifier))
@@ -77,6 +92,8 @@ export class Diagnostics {
 
         this.createInvalidControllerDiagnosticFor(identifier, textDocument, attributeValueRange)
       }
+
+      if (controller && controller.parseError) return
 
       if (controller && methodName && !controller.methods.includes(methodName)) {
         const attributeValueRange = this.attributeValueRange(textDocument, node, this.actionAttribute, methodName)
@@ -164,6 +181,8 @@ export class Diagnostics {
         const camelizedValueName = camelize(valueName)
         const valueDefiniton = controller.values[camelizedValueName]
 
+        if (controller && controller.parseError) return
+
         if (controller && !valueDefiniton) {
           const attributeNameRange = this.attributeNameRange(textDocument, node, attribute, valueName)
           this.createMissingValueOnControllerDiagnosticFor(
@@ -206,7 +225,7 @@ export class Diagnostics {
   }
 
   validateDataClassAttribute(_node: Node, _textDocument: TextDocument) {
-    // TODO: implemenet
+    // TODO: implement
   }
 
   validateDataTargetAttribute(node: Node, textDocument: TextDocument) {
@@ -230,6 +249,8 @@ export class Diagnostics {
           return
         }
 
+        if (controller && controller.parseError) return
+
         if (controller && !controller.targets.includes(targetName)) {
           const attributeNameRange = this.attributeValueRange(textDocument, node, attribute, targetName)
 
@@ -240,6 +261,7 @@ export class Diagnostics {
   }
 
   visitNode(node: Node, textDocument: TextDocument) {
+    this.validateParsedControllerWithoutErrors(node, textDocument)
     this.validateDataControllerAttribute(node, textDocument)
     this.validateDataActionAttribute(node, textDocument)
     this.validateDataValueAttribute(node, textDocument)
@@ -322,6 +344,16 @@ export class Diagnostics {
     const attributeValueEnd = attributeValueStart + search.length
 
     return Range.create(textDocument.positionAt(attributeValueStart), textDocument.positionAt(attributeValueEnd))
+  }
+
+  private createParseErrorDiagnosticFor(identifier: string, textDocument: TextDocument, range: Range) {
+    this.pushDiagnostic(
+      `There was an error parsing the "${identifier}" Stimulus controller. Please check the controller for syntax errors.`,
+      "stimulus.controller.parse_error",
+      range,
+      textDocument,
+      { identifier },
+    )
   }
 
   private createInvalidControllerDiagnosticFor(identifier: string, textDocument: TextDocument, range: Range) {


### PR DESCRIPTION
First attempt at #84 

It first does a check if the controller has any parsing errors, if so adds a new error to the `data-controller` field. It then also ignores all other errors, as they make no sense. See this screenshot, where the only error is the parsing error:

![CleanShot 2023-11-17 at 11 24 00@2x](https://github.com/marcoroth/stimulus-lsp/assets/170034/70a7e15f-fa16-4742-9a8f-3cea3f3ce703)
When I fix the controller to be parsable, you see it shows the actual errors again:

![CleanShot 2023-11-17 at 11 21 46@2x](https://github.com/marcoroth/stimulus-lsp/assets/170034/67d3eedd-435d-4c10-95a6-97231551966c)

Let me know what you think! Especially on the naming of the internal methods and consts and on the error message itself.