### PR TITLE
Show unregistered controller identifiers in Tree View 

### DIFF
--- a/client/src/requests.ts
+++ b/client/src/requests.ts
@@ -1,7 +1,26 @@
-type ControllerDefinition = {
+import { Position } from "vscode-languageclient"
+
+export type ControllerDefinition = {
   identifier: string
   path: string
+  registered: boolean
+  position: Position
+}
+
+export interface ControllerDefinitionsOrigin {
+  name: string,
+  controllerDefinitions: ControllerDefinition[]
+}
+
+export interface ProjectControllerDefinitions extends ControllerDefinitionsOrigin {
+  name: "project",
 }
 
 export type ControllerDefinitionsRequest = object
-export type ControllerDefinitionsResponse = ControllerDefinition[]
+export type ControllerDefinitionsResponse = {
+  registered: ProjectControllerDefinitions
+  unregistered: {
+    project: ProjectControllerDefinitions,
+    nodeModules: ControllerDefinitionsOrigin[]
+  }
+}

--- a/server/src/requests.ts
+++ b/server/src/requests.ts
@@ -1,7 +1,26 @@
-type ControllerDefinition = {
+import { Position } from "vscode-languageserver"
+
+export type ControllerDefinition = {
   identifier: string
   path: string
+  registered: boolean
+  position: Position
+}
+
+export interface ControllerDefinitionsOrigin {
+  name: string,
+  controllerDefinitions: ControllerDefinition[]
+}
+
+export interface ProjectControllerDefinitions extends ControllerDefinitionsOrigin {
+  name: "project",
 }
 
 export type ControllerDefinitionsRequest = object
-export type ControllerDefinitionsResponse = ControllerDefinition[]
+export type ControllerDefinitionsResponse = {
+  registered: ProjectControllerDefinitions
+  unregistered: {
+    project: ProjectControllerDefinitions,
+    nodeModules: ControllerDefinitionsOrigin[]
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,12 +7,18 @@ import {
   TextDocumentSyncKind,
   InitializeResult,
   Diagnostic,
+  Position,
 } from "vscode-languageserver/node"
 
 import { Service } from "./service"
 import { StimulusSettings } from "./settings"
+import { RegisteredController, ControllerDefinition } from "stimulus-parser"
 
-import type { ControllerDefinitionsRequest, ControllerDefinitionsResponse } from "./requests"
+import type {
+  ControllerDefinition as ControllerDefinitionRequestType,
+  ControllerDefinitionsRequest,
+  ControllerDefinitionsResponse,
+} from "./requests"
 
 let service: Service
 const connection = createConnection(ProposedFeatures.all)
@@ -134,14 +140,59 @@ connection.onCompletionResolve((item) => {
 connection.onRequest(
   "stimulus-lsp/controllerDefinitions",
   async (_request: ControllerDefinitionsRequest): Promise<ControllerDefinitionsResponse> => {
-    const controllerDefinitions = service.project.registeredControllers.sort((a, b) =>
-      a.identifier.localeCompare(b.identifier),
-    )
+    const sort = (a: ControllerDefinitionRequestType, b: ControllerDefinitionRequestType) =>
+      a.identifier.localeCompare(b.identifier)
 
-    return controllerDefinitions.map(({ path, identifier }) => ({
+    const mapRegisteredController = ({ path, identifier, classDeclaration: { node } }: RegisteredController) => ({
       path,
       identifier,
-    }))
+      registered: true,
+      position: Position.create(node?.loc?.start.line || 1, node?.loc?.start.column || 1),
+    })
+
+    const mapControllerDefinition = ({
+      path,
+      guessedIdentifier,
+      classDeclaration: { node },
+    }: ControllerDefinition) => ({
+      path,
+      identifier: guessedIdentifier,
+      registered: false,
+      position: Position.create(node?.loc?.start.line || 1, node?.loc?.start.column || 1),
+    })
+
+    const registeredControllerPaths = service.project.registeredControllers.map((c) => c.path)
+    const unregisteredControllerDefinitions = service.project.controllerDefinitions.filter(
+      (definition) => !registeredControllerPaths.includes(definition.path),
+    )
+
+    const registered = service.project.registeredControllers.map(mapRegisteredController).sort(sort)
+    const unregistered = unregisteredControllerDefinitions.map(mapControllerDefinition).sort(sort)
+
+    const nodeModules = service.project.detectedNodeModules
+      .map(({ name, controllerDefinitions }) => ({
+        name,
+        controllerDefinitions: controllerDefinitions
+          .filter((definition) => !registeredControllerPaths.includes(definition.path))
+          .map(mapControllerDefinition)
+          .sort(sort),
+      }))
+      .filter((m) => m.controllerDefinitions.length > 0)
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    return {
+      registered: {
+        name: "project",
+        controllerDefinitions: registered,
+      },
+      unregistered: {
+        project: {
+          name: "project",
+          controllerDefinitions: unregistered,
+        },
+        nodeModules,
+      },
+    }
   },
 )
 


### PR DESCRIPTION
This pull requests adds two new sections to the Tree View. 

The previous list is now under the `Registered` section. Additionally, we now show an `Unregistered` section that lists all the controllers the parser detected and that weren't registered on the application.

![CleanShot 2024-02-24 at 11 03 05](https://github.com/marcoroth/stimulus-lsp/assets/6411752/5a8b2df8-a321-4e1f-bde1-4d064e2d0877)
