### PR TITLE
Add `registerControllerDefinition` command to Tree View Items 

### DIFF
--- a/client/src/requests.ts
+++ b/client/src/requests.ts
@@ -5,6 +5,8 @@ export type ControllerDefinition = {
   path: string
   registered: boolean
   position: Position
+  importStatement?: string
+  localName?: string
 }
 
 export interface ControllerDefinitionsOrigin {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
         "command": "controllerDefinitions.refreshEntry",
         "title": "Refresh Stimulus Controller Definitions",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "controllerDefinitions.registerControllerDefinition",
+        "title": "Register controller definition on the Stimulus Application",
+        "icon": "$(add)"
       }
     ],
     "menus": {
@@ -80,6 +85,13 @@
           "command": "controllerDefinitions.refreshEntry",
           "when": "view == controllerDefinitions",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "controllerDefinitions.registerControllerDefinition",
+          "when": "view == controllerDefinitions && viewItem == controllerDefinition-unregistered-importable",
+          "group": "inline"
         }
       ]
     },

--- a/server/src/requests.ts
+++ b/server/src/requests.ts
@@ -5,6 +5,8 @@ export type ControllerDefinition = {
   path: string
   registered: boolean
   position: Position
+  importStatement?: string
+  localName?: string
 }
 
 export interface ControllerDefinitionsOrigin {

--- a/server/src/service.ts
+++ b/server/src/service.ts
@@ -47,6 +47,7 @@ export class Service {
 
     // TODO: we need to setup a file listener to check when new packages get installed
     await this.project.detectAvailablePackages()
+    await this.project.analyzeAllDetectedModules()
 
     // Only keep settings for open documents
     this.documentService.onDidClose((change) => {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,4 +1,7 @@
+import path from "path"
 import { levenshtein } from "./levenshtein"
+
+import type { Project, ExportDeclaration, ControllerDefinition } from "stimulus-parser"
 
 function rank(input: string, list: string[]) {
   return list
@@ -30,4 +33,80 @@ export function dasherize(value: string) {
 
 export function capitalize(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function importStatementForController(controllerDefinition: ControllerDefinition, project: Project) {
+  const importSource = importSourceForController(controllerDefinition, project)
+  const exportDeclaration = exportDeclarationFromControllerDefinition(controllerDefinition, project)
+
+  if (!exportDeclaration) return { importStatement: undefined, localName: undefined, importSpecifier: undefined, importSource, exportDeclaration }
+
+  return importStatementFromExportDeclaration(exportDeclaration, controllerDefinition, importSource)
+}
+
+export function importSourceForController(controllerDefinition: ControllerDefinition, project: Project) {
+  if (controllerDefinition.sourceFile.isProjectFile) {
+    return relativeControllersFilePath(project, controllerDefinition.sourceFile.path)
+  }
+
+  const nodeModule = nodeModleForController(controllerDefinition, project)
+
+  return nodeModule?.name || ""
+}
+
+export function nodeModleForController(controllerDefinition: ControllerDefinition, project: Project) {
+  return project.detectedNodeModules.find((module) => module.sourceFiles.includes(controllerDefinition.sourceFile))
+}
+
+export function localNameForExportDeclaration(exportDeclaration: ExportDeclaration, controller: ControllerDefinition) {
+  return exportDeclaration.type === "default"
+    ? controller.classDeclaration.className || capitalize(camelize(controller.guessedIdentifier))
+    : exportDeclaration.exportedName || controller.guessedIdentifier
+}
+
+export function importStatementFromExportDeclaration(
+  exportDeclaration: ExportDeclaration,
+  controller: ControllerDefinition,
+  importSource: string,
+) {
+  const exportType = exportDeclaration?.type
+  const localName = localNameForExportDeclaration(exportDeclaration, controller)
+  const importSpecifier = exportType === "default" ? localName : `{ ${localName} }`
+  const importStatement = `import ${importSpecifier} from "${importSource}"`
+
+  return {
+    exportDeclaration,
+    localName,
+    importSpecifier,
+    importStatement,
+    importSource,
+  }
+}
+
+export function relativeControllersFilePath(project: Project, filePath: string): string {
+  if (!project.controllersFile) return ""
+
+  // TODO: Account for importmaps
+  const relativePath = path.relative(
+    path.dirname(project.controllersFile.path),
+    filePath,
+  )
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`
+}
+
+export function exportDeclarationFromControllerDefinition(controllerDefinition: ControllerDefinition, project: Project) {
+  if (controllerDefinition.sourceFile.isProjectFile) return controllerDefinition.classDeclaration.exportDeclaration
+
+  const nodeModule = nodeModleForController(controllerDefinition, project)
+
+  if (!nodeModule) return undefined
+
+  return nodeModule.entrypointSourceFile?.exportDeclarations.find((exportDeclaration) => {
+    try {
+      return exportDeclaration.nextResolvedClassDeclaration?.controllerDefinition === controllerDefinition
+    } catch(error: any) {
+      return false
+    }
+  })
 }


### PR DESCRIPTION
This pull request adds a  `controllerDefinitions.registerControllerDefinition` command that also gets added to any unregistered controller item in the Tree View.

It uses the `stimulus.controller.register` code action introduced in #205 under the hood.

![CleanShot 2024-02-24 at 12 05 41](https://github.com/marcoroth/stimulus-lsp/assets/6411752/b6c104b5-bc8b-4e01-ac09-1184002c5b23)
