### PR TITLE
Implement `stimulus.controller.action.update` code action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently, this Language Server only works for HTML, though its utility extends 
 
 * Create unknown controllers (`stimulus.controller.create`)
 * Update controller identifier with did you mean suggestion (`stimulus.controller.update`)
+* Update controller action name with did you mean suggestion (`stimulus.controller.action.update`)
 
 ## Structure
 

--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -59,6 +59,21 @@ export class Commands {
     })
   }
 
+  async updateControllerActionReference(actionName: string, diagnostic: Diagnostic, suggestion: string) {
+    if (actionName === undefined) return
+    if (diagnostic === undefined) return
+    if (suggestion === undefined) return
+
+    const { textDocument, range } = diagnostic.data as { textDocument: SerializedTextDocument; range: Range }
+
+    const document = { uri: textDocument._uri, version: textDocument._version }
+    const textEdit: TextEdit = { range, newText: suggestion }
+
+    const documentChanges: TextDocumentEdit[] = [TextDocumentEdit.create(document, [textEdit])]
+
+    await this.connection.workspace.applyEdit({ documentChanges })
+  }
+
   private controllerTemplateFor(identifier: string) {
     return dedent`
       import { Controller } from "@hotwired/stimulus"

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -16,6 +16,12 @@ export interface InvalidControllerDiagnosticData {
   suggestion: string
 }
 
+export interface InvalidActionDiagnosticData {
+  identifier: string
+  actionName: string
+  suggestion: string
+}
+
 export class Diagnostics {
   private readonly connection: Connection
   private readonly stimulusDataProvider: StimulusHTMLDataProvider
@@ -447,7 +453,7 @@ export class Diagnostics {
       "stimulus.controller.action.invalid",
       range,
       textDocument,
-      { identifier, actionName },
+      { identifier, actionName, suggestion: match, textDocument, range },
     )
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -34,7 +34,7 @@ connection.onInitialize(async (params: InitializeParams) => {
       codeActionProvider: true,
       definitionProvider: true,
       executeCommandProvider: {
-        commands: ["stimulus.controller.create", "stimulus.controller.update"],
+        commands: ["stimulus.controller.create", "stimulus.controller.update", "stimulus.controller.action.update"],
       },
     },
   }
@@ -111,6 +111,12 @@ connection.onExecuteCommand((params) => {
     const [identifier, diagnostic, suggestion] = params.arguments as [string, Diagnostic, string]
 
     service.commands.updateControllerReference(identifier, diagnostic, suggestion)
+  }
+
+  if (params.command === "stimulus.controller.action.update") {
+    const [actionName, diagnostic, suggestion] = params.arguments as [string, Diagnostic, string]
+
+    service.commands.updateControllerActionReference(actionName, diagnostic, suggestion)
   }
 })
 


### PR DESCRIPTION
This pull request implements the `stimulus.controller.action.update` code action to resolve the `stimulus.controller.action.invalid` diagnostic. This code action be used to replace the invalid controller action name with the did you mean suggested.

![CleanShot 2024-03-02 at 03 07 18](https://github.com/marcoroth/stimulus-lsp/assets/6411752/b8ad1688-36d0-47aa-8f36-c9d3060e1bf3)

![CleanShot 2024-03-02 at 03 07 37](https://github.com/marcoroth/stimulus-lsp/assets/6411752/44fe2ffc-3c83-4676-84bd-02368e3725d0)

![CleanShot 2024-03-02 at 03 07 42](https://github.com/marcoroth/stimulus-lsp/assets/6411752/217b4686-e1a9-4980-b8f6-740f02b81a03)


Resolves https://github.com/marcoroth/stimulus-lsp/issues/161