### PR TITLE
Don't provide `stimulus.controller.update` action if suggestion is null

### DIFF
--- a/server/src/code_actions.ts
+++ b/server/src/code_actions.ts
@@ -37,29 +37,38 @@ export class CodeActions {
       const controllerRootsInProject = this.project.controllerRoots.filter(
         (project) => !project.includes("node_modules"),
       )
+
       const manyRoots = controllerRootsInProject.length > 1
+
       if (controllerRootsInProject.length === 0) controllerRootsInProject.push(this.project.controllerRootFallback)
 
-      const updateTitle = `Replace "${identifier}" with suggestion: "${suggestion}"`
-      const updateReferenceAction = CodeAction.create(
-        updateTitle,
-        Command.create(updateTitle, "stimulus.controller.update", identifier, diagnostic, suggestion),
-        CodeActionKind.QuickFix,
-      )
+      const codeActions: CodeAction[] = []
 
-      return [
-        updateReferenceAction,
-        ...controllerRootsInProject.map((root) => {
-          const folder = `${manyRoots ? ` in "${root}/"` : ""}`
-          const title = `Create "${identifier}" Stimulus Controller${folder}`
+      if (suggestion) {
+        const updateTitle = `Replace "${identifier}" with suggestion: "${suggestion}"`
+        const updateReferenceAction = CodeAction.create(
+          updateTitle,
+          Command.create(updateTitle, "stimulus.controller.update", identifier, diagnostic, suggestion),
+          CodeActionKind.QuickFix,
+        )
 
-          return CodeAction.create(
-            title,
-            Command.create(title, "stimulus.controller.create", identifier, diagnostic, root),
-            CodeActionKind.QuickFix,
-          )
-        }),
-      ]
+        codeActions.push(updateReferenceAction)
+      }
+
+      const createControllerActions = controllerRootsInProject.map((root) => {
+        const folder = `${manyRoots ? ` in "${root}/"` : ""}`
+        const title = `Create "${identifier}" Stimulus Controller${folder}`
+
+        return CodeAction.create(
+          title,
+          Command.create(title, "stimulus.controller.create", identifier, diagnostic, root),
+          CodeActionKind.QuickFix,
+        )
+      })
+
+      codeActions.push(...createControllerActions)
+
+      return codeActions
     })
   }
 


### PR DESCRIPTION
This pull request changes the behavior so that the LSP doesn't provide the `stimulus.controller.update` code action for a `stimulus.controller.invalid` diagnostic if the `suggestion` is `null`.

| Before | After |
| --- | --- |
| ![CleanShot 2024-03-02 at 16 50 10](https://github.com/marcoroth/stimulus-lsp/assets/6411752/57cf6f8d-72c6-4348-88ca-3b8c4f727976) | ![CleanShot 2024-03-02 at 16 48 42](https://github.com/marcoroth/stimulus-lsp/assets/6411752/fbbf17a8-2566-47c2-9114-ef35b0640c3d) |


Resolves https://github.com/marcoroth/stimulus-lsp/issues/156