### PR TITLE
Implement `stimulus.controller.register` code action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Currently, this Language Server only works for HTML, though its utility extends 
 
 ### Quick-Fixes
 
-* Create unknown controllers (`stimulus.controller.create`)
+* Create a controller with the given identifier (`stimulus.controller.create`)
 * Update controller identifier with did you mean suggestion (`stimulus.controller.update`)
+* Register a controller definition from your project or a NPM package (`stimulus.controller.register`)
 * Update controller action name with did you mean suggestion (`stimulus.controller.action.update`)
-* Implement invalid controller action name on controller (`stimulus.controller.action.implement`)
+* Implement a missing controller action on controller (`stimulus.controller.action.implement`)
 
 ## Structure
 

--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -36,6 +36,32 @@ export class Commands {
     await this.connection.workspace.applyEdit({ documentChanges })
   }
 
+  async registerControllerDefinition(importStatement: string, identifier: string, localName: string) {
+    if (importStatement === undefined) return
+    if (identifier === undefined) return
+    if (localName === undefined) return
+    if (!this.project.controllersFile) return
+
+    // TODO: there must be a better way to get the end of the file without having the textDocument
+    const endOfFile = { line: 10000000, character: 0 }
+
+    const uri = `file://${this.project.controllersFile.path}`
+    const document = { uri, version: null }
+    const textEdit: TextEdit = {
+      range: { start: endOfFile, end: endOfFile },
+      newText: `\n\n${importStatement}\napplication.register("${identifier}", ${localName})\n`,
+    }
+
+    const documentChanges: TextDocumentEdit[] = [TextDocumentEdit.create(document, [textEdit])]
+
+    await this.connection.workspace.applyEdit({ documentChanges })
+    await this.connection.window.showDocument({
+      uri,
+      external: false,
+      takeFocus: true,
+    })
+  }
+
   async createController(identifier: string, diagnostic: Diagnostic, controllerRoot: string) {
     if (identifier === undefined) return
     if (diagnostic === undefined) return

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -37,6 +37,7 @@ connection.onInitialize(async (params: InitializeParams) => {
         commands: [
           "stimulus.controller.create",
           "stimulus.controller.update",
+          "stimulus.controller.register",
           "stimulus.controller.action.update",
           "stimulus.controller.action.implement",
         ],
@@ -68,7 +69,7 @@ connection.onInitialized(() => {
   }
 
   connection.client.register(DidChangeWatchedFilesNotification.type, {
-    watchers: service.stimulusDataProvider.controllerRoots.map((root) => ({ globPattern: `**/${root}/**/*` })),
+    watchers: service.project.controllerRoots.map((root) => ({ globPattern: `**/${root}/**/*` })),
   })
 
   connection.client.register(DidChangeWatchedFilesNotification.type, {
@@ -97,7 +98,14 @@ connection.onDidOpenTextDocument((params) => {
   }
 })
 
-connection.onDidChangeWatchedFiles(() => service.refresh())
+connection.onDidChangeWatchedFiles((_params) => {
+  // params.changes.forEach((event) => {
+  //   service.refreshFile(event)
+  // })
+
+  service.refresh()
+})
+
 connection.onDefinition((params) => service.definitions.onDefinition(params))
 connection.onCodeAction((params) => service.codeActions.onCodeAction(params))
 connection.onCodeLens((params) => service.codeLens.onCodeLens(params))
@@ -128,6 +136,12 @@ connection.onExecuteCommand((params) => {
     const [identifer, actionName, diagnostic] = params.arguments as [string, string, Diagnostic]
 
     service.commands.implementControllerAction(identifer, actionName, diagnostic)
+  }
+
+  if (params.command === "stimulus.controller.register") {
+    const [importStatement, identifier, localName] = params.arguments as [string, string, string]
+
+    service.commands.registerControllerDefinition(importStatement, identifier, localName)
   }
 })
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -27,3 +27,7 @@ export function camelize(value: string) {
 export function dasherize(value: string) {
   return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`)
 }
+
+export function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}


### PR DESCRIPTION
This pull request adds the `stimulus.controller.register` code action which can be used to resolve a `stimulus.controller.invalid` diagnostic. The code action is provided if the invalid identifier was recognized in one of the controller definitions in the project that weren't registered yet or if any of the installed node modules exposes a controller with such an identifier.

https://github.com/marcoroth/stimulus-lsp/assets/6411752/c740aa8d-735a-4947-b10c-ff240857ca3e

Resolves https://github.com/marcoroth/stimulus-lsp/issues/175