### PR TITLE
Validate Default Value types in Value Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Currently, this Language Server only works for HTML, though its utility extends 
 
 ### Diagnostics
 
+#### HTML Files
+
 * Missing controllers (`stimulus.controller.invalid`)
 * Missing controller actions (`stimulus.action.invalid`)
 * Missing controller targets (`stimulus.controller.target.missing`)
@@ -27,6 +29,10 @@ Currently, this Language Server only works for HTML, though its utility extends 
 * Invalid action descriptors (`stimulus.action.invalid`)
 * Data attributes format mismatches (`stimulus.attribute.mismatch`)
 * Controller values type mismatches (`stimulus.controller.value.type_mismatch`)
+
+#### JavaScript Files/Stimulus Controller Files
+
+* Controller value definition default value type mismatch (`stimulus.controller.value_definition.default_value.type_mismatch`)
 * Controller parsing errors (`stimulus.controller.parse_error`)
 
 ### Quick-Fixes

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent"
 import { Connection, Diagnostic, DiagnosticSeverity, Position, Range } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { getLanguageService, Node } from "vscode-html-languageservice"
@@ -314,8 +315,14 @@ export class Diagnostics {
         const defaultValueType = this.parseValueType(valueDefinition.default)
 
         if (valueDefinition.type !== defaultValueType) {
+          const message = dedent`
+            The type of the default value you provided doesn't match the type you defined.
+            The "${valueDefinition.name}" Stimulus Value is of type \`${valueDefinition.type}\`.
+            The default value you provided for "${valueDefinition.name}" is of type \`${defaultValueType}\`.
+          `
+
           this.pushDiagnostic(
-            `Default Value type mismatch. The "${valueDefinition.name}" value is defined as type "${valueDefinition.type}" but the default value you passed is of type "${defaultValueType}".`,
+            message,
             "stimulus.controller.value_definition.default_value.type_mismatch",
             range,
             textDocument,


### PR DESCRIPTION
This pull request introduces the `stimulus.controller.value_definition.default_value.type_mismatch` diagnostic which will be added to any JavaScript/TypeScript file that doesn't have a matching default value type.

![CleanShot 2024-03-03 at 04 36 06](https://github.com/marcoroth/stimulus-lsp/assets/6411752/32bbbedb-52ab-406c-bfb8-21c353784bd3)


Resolves https://github.com/marcoroth/stimulus-lsp/issues/169