### PR TITLE
Add diagnostics for Stimulus Value types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently, this Language Server only works for HTML, though its utility extends 
 #### JavaScript Files/Stimulus Controller Files
 
 * Controller value definition default value type mismatch (`stimulus.controller.value_definition.default_value.type_mismatch`)
+* Unknown value definition type (`stimulus.controller.value_definition.unknown_type`)
 * Controller parsing errors (`stimulus.controller.parse_error`)
 
 ### Quick-Fixes


### PR DESCRIPTION
This pull requests adds the `stimulus.controller.value_definition.unknown_type` diagnostic. We show this diagnostic when the given type for a Stimulus value is none of the known types (`Array`, `Boolean`, `Number`, `Object` or `String`).

![CleanShot 2024-03-05 at 04 30 32](https://github.com/marcoroth/stimulus-lsp/assets/6411752/3a1a037b-636e-4d8d-bae3-42eff78f4977)
