### PR TITLE
Implement `stimulus.package.deprecated.import` diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently, this Language Server only works for HTML, though its utility extends 
 * Controller value definition default value type mismatch (`stimulus.controller.value_definition.default_value.type_mismatch`)
 * Unknown value definition type (`stimulus.controller.value_definition.unknown_type`)
 * Controller parsing errors (`stimulus.controller.parse_error`)
+* Import from the old deprected packages (`stimulus.package.deprecated.import`)
 
 ### Quick-Fixes
 


### PR DESCRIPTION
This pull request adds the  `stimulus.package.deprecated.import` diagnostic which gets added to import declarations that use the deprecated `stimulus` or `@stimulus/webpack-helpers` package.

![CleanShot 2024-03-05 at 05 14 03](https://github.com/marcoroth/stimulus-lsp/assets/6411752/9f1cea0e-9ddd-45cb-9f55-99d06ecb28b8)

Resolves https://github.com/marcoroth/stimulus-lsp/issues/155