### PR TITLE
Improve range-accuracy on value definition diagnostics

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -356,10 +356,11 @@ export class Diagnostics {
       if (controller.values.length === 0) return
 
       controller.values.forEach((valueDefinition) => {
-        const range = this.rangeFromLoc(textDocument, valueDefinition.node.loc)
         const defaultValueType = this.parseValueType(valueDefinition.default)
 
         if (!["Array", "Boolean", "Number", "Object", "String"].includes(valueDefinition.type)) {
+          const range = this.rangeFromLoc(textDocument, valueDefinition.typeLoc)
+
           this.pushDiagnostic(
             `Unknown Value type. The "${valueDefinition.name}" value is defined as type "${valueDefinition.type}". \nPossible Values: \`Array\`, \`Boolean\`, \`Number\`, \`Object\`, or \`String\`.\n`,
             "stimulus.controller.value_definition.unknown_type",
@@ -373,6 +374,8 @@ export class Diagnostics {
         }
 
         if (valueDefinition.type !== defaultValueType) {
+          const range = this.rangeFromLoc(textDocument, valueDefinition.defaultValueLoc)
+
           const message = dedent`
             The type of the default value you provided doesn't match the type you defined.
             The "${valueDefinition.name}" Stimulus Value is of type \`${valueDefinition.type}\`.


### PR DESCRIPTION
part of #248 and initial setup for adding suggestions / code actions for https://github.com/marcoroth/stimulus-lsp/issues/213 

Based on https://github.com/marcoroth/stimulus-parser/pull/114 and https://github.com/marcoroth/stimulus-parser/pull/117.

Display diagnostic only on the offending type value instead of the whole value object.
### Before
<img width="503" alt="Screenshot 2024-04-11 at 4 30 17 PM" src="https://github.com/marcoroth/stimulus-lsp/assets/33430835/9f131e3f-a37d-406a-9697-5c8b2b2a0ca0">


### After
<img width="572" alt="Screenshot 2024-04-11 at 4 26 08 PM" src="https://github.com/marcoroth/stimulus-lsp/assets/33430835/21ac4652-e164-47a9-a2bb-e3c95f9c87cb">
