### PR TITLE
check for duplicate diagnostics before adding new one

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -651,7 +651,14 @@ export class Diagnostics {
     }
 
     const diagnostics = this.diagnostics.get(textDocument) || []
-    diagnostics.push(diagnostic)
+
+    const duplicateDiagnostic = diagnostics.find((d) => {
+      return JSON.stringify(d) === JSON.stringify(diagnostic)
+    })
+
+    if(!duplicateDiagnostic) {
+      diagnostics.push(diagnostic)
+    }
 
     this.diagnostics.set(textDocument, diagnostics)
 


### PR DESCRIPTION
possible fix #275

Alternatively, I tried checking if [`service.refresh()`](https://github.com/marcoroth/stimulus-lsp/blob/27a7283941dd75d5f945d48cf228d189453aa736/server/src/service.ts#L64) was called multiple times unnecessarily but that was not the case.