### PR TITLE
Don't include file extension when registering controllers

### DIFF
--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -60,7 +60,7 @@ export function nodeModleForController(controllerDefinition: ControllerDefinitio
 
 export function localNameForExportDeclaration(exportDeclaration: ExportDeclaration, controller: ControllerDefinition) {
   return exportDeclaration.type === "default"
-    ? controller.classDeclaration.className || capitalize(camelize(controller.guessedIdentifier))
+    ? controller.classDeclaration.className || `${capitalize(camelize(controller.guessedIdentifier))}Controller`
     : exportDeclaration.exportedName || controller.guessedIdentifier
 }
 
@@ -92,7 +92,17 @@ export function relativeControllersFilePath(project: Project, filePath: string):
     filePath,
   )
 
-  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`
+  const fileName = path.basename(
+    relativePath,
+    path.extname(relativePath)
+  )
+
+  const controllerPath = path.join(
+    path.dirname(relativePath),
+    fileName
+  )
+
+  return controllerPath.startsWith(".") ? controllerPath : `./${controllerPath}`
 }
 
 export function exportDeclarationFromControllerDefinition(controllerDefinition: ControllerDefinition, project: Project) {


### PR DESCRIPTION
| **Before** | **After** |
| --- | --- |
| ![CleanShot 2024-05-16 at 13 56 45@2x](https://github.com/marcoroth/stimulus-lsp/assets/6411752/267e50e3-76c5-4c1a-9f5a-bddc47c490b3) | ![CleanShot 2024-05-16 at 13 57 09@2x](https://github.com/marcoroth/stimulus-lsp/assets/6411752/4c9ae608-e02e-446a-a84e-65f3084ec090) |

Fixes #281 
