### PR TITLE
Introduce `Config` class to configure ignore-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Currently, this Language Server only works for HTML, though its utility extends 
 * Register a controller definition from your project or a NPM package (`stimulus.controller.register`)
 * Update controller action name with did you mean suggestion (`stimulus.controller.action.update`)
 * Implement a missing controller action on controller (`stimulus.controller.action.implement`)
+* Create a default config file at `.stimulus-lsp/config.json` (`stimulus.config.create`)
+* Ignore diagnostics for a HTML attribute by adding it to the `ignoredAttributes` config (`stimulus.config.attribute.ignore`)
+* Ignore diagnostics for a Stimulus controller identifier by adding it to the `ignoredControllerIdentifiers` config (`stimulus.config.controller.ignore`)
 
 ## Structure
 

--- a/server/src/code_actions.ts
+++ b/server/src/code_actions.ts
@@ -134,6 +134,34 @@ export class CodeActions {
 
       codeActions.push(...createControllerActions)
 
+      // Code Action: stimulus.config.attribute.ignore
+
+      const { attribute } = diagnostic?.data?.data || {}
+
+      if (attribute) {
+        const ignoreAttributeTitle = `Ignore diagnostics for "${attribute}" attribute.`
+
+        const ignoreAttributeAction = CodeAction.create(
+          ignoreAttributeTitle,
+          Command.create(ignoreAttributeTitle, "stimulus.config.attribute.ignore", attribute, diagnostic),
+          CodeActionKind.QuickFix,
+        )
+
+        codeActions.push(ignoreAttributeAction)
+      }
+
+      // Code Action: stimulus.config.controller.ignore
+
+      const ignoreControllerTitle = `Ignore diagnostics for "${identifier}" controller.`
+
+      const ignoreControllerAction = CodeAction.create(
+        ignoreControllerTitle,
+        Command.create(ignoreControllerTitle, "stimulus.config.controller.ignore", identifier, diagnostic),
+        CodeActionKind.QuickFix,
+      )
+
+      codeActions.push(ignoreControllerAction)
+
       return codeActions
     })
   }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,129 @@
+export type StimulusConfigOptions = {
+  ignoredControllerIdentifiers: Array<string>
+  ignoredAttributes: Array<string>
+}
+
+export type StimulusLSPConfig = {
+  version: string
+  createdAt: string
+  updatedAt: string
+  options: StimulusConfigOptions
+}
+
+import path from "path"
+import { version } from "../package.json"
+import { promises as fs } from "fs"
+
+export class Config {
+  static configPath = ".stimulus-lsp/config.json"
+
+  public readonly path: string
+  public config: StimulusLSPConfig
+
+  constructor(projectPath: string, config: StimulusLSPConfig) {
+    this.path = Config.configPathFromProjectPath(projectPath)
+    this.config = config
+  }
+
+  get version(): string {
+    return this.config.version
+  }
+
+  get createdAt(): Date {
+    return new Date(this.config.createdAt)
+  }
+
+  get updatedAt(): Date {
+    return new Date(this.config.updatedAt)
+  }
+
+  get options(): StimulusConfigOptions {
+    return this.config.options
+  }
+
+  get ignoredControllerIdentifiers(): Array<string> {
+    return this.options.ignoredControllerIdentifiers
+  }
+
+  get ignoredAttributes(): Array<string> {
+    return this.options.ignoredAttributes
+  }
+
+  public addIgnoredController(identifier: string) {
+    const identifiers = this.ignoredControllerIdentifiers
+    identifiers.push(identifier)
+
+    this.options.ignoredControllerIdentifiers = Array.from(new Set(identifiers)).sort()
+  }
+
+  public addIgnoredAttribute(attribute: string) {
+    const attributes = this.ignoredAttributes
+    attributes.push(attribute)
+
+    this.options.ignoredAttributes = Array.from(new Set(attributes)).sort()
+  }
+
+  public toJSON() {
+    return JSON.stringify(this.config, null, "  ")
+  }
+
+  private updateTimestamp() {
+    this.config.updatedAt = new Date().toISOString()
+  }
+
+  private updateVersion() {
+    this.config.version = version
+  }
+
+  async write() {
+    this.updateVersion()
+    this.updateTimestamp()
+
+    const folder = path.dirname(this.path)
+
+    fs.stat(folder)
+      .then(() => {})
+      .catch(async () => await fs.mkdir(folder))
+      .finally(async () => await fs.writeFile(this.path, this.toJSON()))
+  }
+
+  async read() {
+    return await fs.readFile(this.path, "utf8")
+  }
+
+  static configPathFromProjectPath(projectPath: string) {
+    return path.join(projectPath, this.configPath)
+  }
+
+  static async fromPathOrNew(projectPath: string) {
+    try {
+      return await this.fromPath(projectPath)
+    } catch (error: any) {
+      return Config.newConfig(projectPath)
+    }
+  }
+
+  static async fromPath(projectPath: string) {
+    const configPath = Config.configPathFromProjectPath(projectPath)
+
+    try {
+      const config = JSON.parse(await fs.readFile(configPath, "utf8"))
+
+      return new Config(projectPath, config)
+    } catch (error: any) {
+      throw new Error(`Error reading config file at: ${configPath}. Error: ${error.message}`)
+    }
+  }
+
+  static newConfig(projectPath: string): Config {
+    return new Config(projectPath, {
+      version,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      options: {
+        ignoredControllerIdentifiers: [],
+        ignoredAttributes: []
+      }
+    })
+  }
+}

--- a/server/src/service.ts
+++ b/server/src/service.ts
@@ -8,6 +8,7 @@ import { Diagnostics } from "./diagnostics"
 import { Definitions } from "./definitions"
 import { Commands } from "./commands"
 import { CodeActions } from "./code_actions"
+import { Config } from "./config"
 import { CodeLensProvider as CodeLens } from "./code_lens"
 
 import { Project } from "stimulus-parser"
@@ -24,6 +25,7 @@ export class Service {
   codeActions: CodeActions
   project: Project
   codeLens: CodeLens
+  config?: Config
 
   constructor(connection: Connection, params: InitializeParams) {
     this.connection = connection
@@ -32,7 +34,7 @@ export class Service {
     this.project = new Project(this.settings.projectPath.replace("file://", ""))
     this.codeActions = new CodeActions(this.documentService, this.project)
     this.stimulusDataProvider = new StimulusHTMLDataProvider("id", this.project)
-    this.diagnostics = new Diagnostics(this.connection, this.stimulusDataProvider, this.documentService, this.project)
+    this.diagnostics = new Diagnostics(this.connection, this.stimulusDataProvider, this.documentService, this.project, this)
     this.definitions = new Definitions(this.documentService, this.stimulusDataProvider)
     this.commands = new Commands(this.project, this.connection)
     this.codeLens = new CodeLens(this.documentService, this.project)
@@ -48,6 +50,8 @@ export class Service {
     // TODO: we need to setup a file listener to check when new packages get installed
     await this.project.detectAvailablePackages()
     await this.project.analyzeAllDetectedModules()
+
+    this.config = await Config.fromPathOrNew(this.project.projectPath)
 
     // Only keep settings for open documents
     this.documentService.onDidClose((change) => {
@@ -65,5 +69,9 @@ export class Service {
     await this.project.refresh()
 
     this.diagnostics.refreshAllDocuments()
+  }
+
+  async refreshConfig() {
+    this.config = await Config.fromPathOrNew(this.project.projectPath)
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2019", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
This pull request introduces a minimal `Config` object which allows to configure ignore-lists for controller identifiers and HTML attributes. 

The idea is that the `.stimulus-lsp/config.json` file is committed to the git repository so that ignored controllers and attributes are shared between all people the team.

https://github.com/marcoroth/stimulus-lsp/assets/6411752/2181b216-50fd-4c50-94fe-466109d3a035


Resolves https://github.com/marcoroth/stimulus-lsp/issues/75
