### PR TITLE
Add `file://` URI scheme to Stimulus Config Commands

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -188,7 +188,7 @@ export class Commands {
     await config.write()
 
     await this.connection.window.showDocument({
-      uri: config.path,
+      uri: `file://${config.path}`,
       external: false,
       takeFocus: true,
     })
@@ -202,7 +202,7 @@ export class Commands {
     await config.write()
 
     await this.connection.window.showDocument({
-      uri: config.path,
+      uri: `file://${config.path}`,
       external: false,
       takeFocus: true,
     })


### PR DESCRIPTION
Editors other than Visual Studio Code utilize the `file://` URI scheme for the `window.showDocument()` function which is used in the Stimulus Config Code Action Commands.

This pull request adds the `file://` scheme to the newly added Commands in #289.

Fixes https://github.com/marcoroth/stimulus-lsp/issues/75#issuecomment-2127903372 @christopher-b pointed out in #75.