### PR TITLE
Use URI for "createController" command

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -70,7 +70,7 @@ export class Commands {
     if (controllerRoot === undefined) controllerRoot = this.project.controllerRoot
 
     const path = ControllerDefinition.controllerPathForIdentifier(identifier)
-    const newControllerPath = `${this.project.projectPath}/${controllerRoot}/${path}`
+    const newControllerPath = `file://${this.project.projectPath}/${controllerRoot}/${path}`
     const createFile: CreateFile = { kind: "create", uri: newControllerPath }
 
     await this.connection.workspace.applyEdit({ documentChanges: [createFile] })


### PR DESCRIPTION
Hi. This pull request resolves the problem with the "createController" command in editors like Zed (https://github.com/zed-industries/zed/issues/18218).

According to the LSP specification, the "CreateFile" operation uses the `DocumentUri` type for the resource name:

```json
{
  "kind": "create",
  "uri": "file:///Users/file.js"
}
```

However, the "createController" command currently uses an absolute path, which breaks compatibility with
clients other than VSCode. To comply with the specification and make this feature working in other clients,
the command must use a URI in the "CreateFile" operation.

## Details

Stimulus LSP sends this response when you try to create the missing controller via available code actions:


```json
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "workspace/applyEdit",
  "params": {
    "edit": {
      "documentChanges": [
        {
          "kind": "create",
          "uri": "/Users/vslobodin/Development/festivatica/app/javascript/controllers/modal_controller.js"
        }
      ]
    }
  }
}
```

Notice the `uri` field is an absolute path. The Zed editor tries to follow the LSP spec and attempts to deserialise this fields as a DocumentUri and fails. Thus making the code action unavailable. But the same response but with the DocumentUri in the `uri` field makes this code action available again:


```json
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "workspace/applyEdit",
  "params": {
    "edit": {
      "documentChanges": [
        {
          "kind": "create",
          "uri": "file:///Users/vslobodin/Development/festivatica/app/javascript/controllers/modal_controller.js"
        }
      ]
    }
  }
}
```

## How to reproduce

1. Install the Zed editor
1. Install the stimulus extension in Zed
1. Clone this repo https://github.com/vitallium/stimulus-lsp-error-zed and open it in Zed
1. Open the application.html.erb file
1. On line 21, you should see available code action for the line <body data-1. controller="test">. Click on it and select Create "test" Stimulus Controller.
1. Click on it and nothing will happen. 


Let me know if the fix provided here is good enough or you need more details. Thanks. 