### PR TITLE
Report server version on initialization

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,6 +11,7 @@ import {
 
 import { Service } from "./service"
 import { StimulusSettings } from "./settings"
+import { version } from "../package.json"
 
 import { ControllerDefinitionsRequest } from "./requests/controller_definitions"
 
@@ -27,6 +28,10 @@ connection.onInitialize(async (params: InitializeParams) => {
   await service.init()
 
   const result: InitializeResult = {
+    serverInfo: {
+      name: "Stimulus LSP",
+      version
+    },
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: {


### PR DESCRIPTION
Some language servers I use report versions, such as [Ruby LSP](https://github.com/Shopify/ruby-lsp/blob/d4a9dfa3df4e597830f2260f5b1dd40285e7a8ba/lib/ruby_lsp/server.rb#L295-L298) and `vtsls`, which Zed then shows in its summary card.

<img width="455" height="267" alt="Screenshot 2026-04-10 at 16 23 04" src="https://github.com/user-attachments/assets/0a00665c-113b-4df1-a45f-e184855bc1f0" />
