### PR TITLE
Bump Herb to `0.10.3`

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,9 +24,9 @@
     "out"
   ],
   "dependencies": {
-    "@herb-tools/core": "^0.10.1",
-    "@herb-tools/language-service": "^0.10.1",
-    "@herb-tools/node-wasm": "0.10.2",
+    "@herb-tools/core": "^0.10.3",
+    "@herb-tools/language-service": "^0.10.3",
+    "@herb-tools/node-wasm": "0.10.3",
     "@hotwired/stimulus": "https://github.com/hotwired/dev-builds/archive/refs/tags/@hotwired/stimulus/8cbca6d.tar.gz",
     "dedent": "^1.5.1",
     "stimulus-parser": "^0.3.2",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,22 +2,25 @@
 # yarn lockfile v1
 
 
-"@herb-tools/core@0.10.2", "@herb-tools/core@^0.10.1":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.2.tgz#0b76de5746a28f8bd6fdb5d0f0e0ce0c56e88760"
-  integrity sha512-gAZjcgFO0UcQXiRG1hkPAnn6SAX/Jj//Bq2QcFUCLMcbAY0uaF13g7QDiY+ntg9LqmdT5Lka0TXC8mv1ehTk8w==
-
-"@herb-tools/language-service@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@herb-tools/language-service/-/language-service-0.10.1.tgz#a0623e7dfba0f47b88cbe5e6ffaaa3f427646e81"
-  integrity sha512-nIvOFoTdB/N6nihJ4vylIgvpl+mFR/OG0MuDa7/Zag6A3Njkumm7fWyqcOcCk2klkjjhzPE5gOCYKUbn0cEMQw==
-
-"@herb-tools/node-wasm@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.2.tgz#66c1a76fdedcba37ab49d4427875ae76e5adeb92"
-  integrity sha512-gSu674UiuxCL5ypQveQqGd4GMk+iKSmI7Hk2nLIs/L132exrfumVg+Jxd+Nqg6z7lzDbx+/yXLKdMoLIh1OFaw==
+"@herb-tools/core@0.10.3", "@herb-tools/core@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.3.tgz#03b1bf1a5d0c5acf9841209cf0c26dae3e2d85bb"
+  integrity sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==
   dependencies:
-    "@herb-tools/core" "0.10.2"
+    "@ruby/prism" "^1.9.0"
+
+"@herb-tools/language-service@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/language-service/-/language-service-0.10.3.tgz#b4fc796a29b98624ff41589651efb8a198f29762"
+  integrity sha512-RYvpfqKzevimVK18eiRR4J9THCvicZRqHNpypHHMmrMtPr2VOcB8tzqd6nB6PnqOAZ8XrZRE9eV9umdPyQ+u0Q==
+
+"@herb-tools/node-wasm@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.3.tgz#dc1527c2af245f67dbe85e3ba3782aefafc70653"
+  integrity sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==
+  dependencies:
+    "@herb-tools/core" "0.10.3"
+    "@ruby/prism" "^1.9.0"
 
 "@hotwired/stimulus-webpack-helpers@^1.0.1":
   version "1.0.1"
@@ -32,6 +35,11 @@
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
   integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
+
+"@ruby/prism@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ruby/prism/-/prism-1.9.0.tgz#064f599caf2288e8f0738875abbdd4bc4755df95"
+  integrity sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==
 
 "@types/estree@^1.0.5":
   version "1.0.9"


### PR DESCRIPTION
This pull request upgrades the `@herb-tools` packages to `v0.10.3` so the language server stops crashing on startup with `Cannot find module '@ruby/prism/src/deserialize.js'`.

`@herb-tools/core` now marks `@ruby/prism` as external in its Rollup output, so its published bundle requires it at runtime.

Up to `v0.10.2` it was declared only as a `devDependency`, so it was never installed for consumers. The server picked this up when `v1.1.1` moved to `@herb-tools/core@^0.10.1`, and it fails on any clean install, like Zed's extension work directory or the `server/node_modules` tree bundled into the VS Code extension, because nothing else happens to hoist Prism into scope.

A fresh install of the published `stimulus-language-server@1.1.1` already resolves `@herb-tools/core` forward to `v0.10.3` on its own, so Zed is fixed by the upstream release alone once the extension work directory is reinstalled. VS Code is not: `.vscodeignore` does not exclude `server/node_modules`, so the extension ships a dependency tree frozen at publish time and needs a new release to pick this up.

Upstream this was fixed in marcoroth/herb#1806, released as `v0.10.3`, which resolved marcoroth/herb#1756 and marcoroth/herb#1870. 

Resolves #801

Related marcoroth/herb#1871
Related marcoroth/herb#1864

This most likely also resolves #798, which reports `v1.1.0` working and `v1.1.1` failing to start. `v1.1.1` was published on 2026-06-05 and is exactly the release that moved to `@herb-tools/core@^0.10.1`, with #798 filed a week later. 
