### PR TITLE
Add npm trusted publishing for `stimulus-language-server`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [24]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,18 @@ on:
     types:
       - created
 
+  workflow_dispatch:
+    inputs:
+      vscode:
+        description: 'Also publish the VS Code extension'
+        type: boolean
+        default: false
+
 jobs:
   publish:
     name: Publish VSCode extension
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' || inputs.vscode
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.node-version'
           cache: 'yarn'
 
       - name: Yarn install
@@ -33,3 +33,38 @@ jobs:
         run: yarn run deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  npm:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+
+      - name: Update npm
+        run: npm install --global npm@latest
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Yarn build
+        run: yarn build
+
+      - name: Build server
+        run: yarn build
+        working-directory: server
+
+      - name: Publish with provenance
+        run: npm publish --provenance --access public --ignore-scripts
+        working-directory: server


### PR DESCRIPTION
This pull request adds a job to publish `stimulus-language-server` to npm using [trusted publishing](https://docs.npmjs.com/trusted-publishers), so the package is released from CI with provenance instead of by hand. Only the VS Code extension was published automatically until now, which is why `v1.1.2` shipped to the Marketplace but never made it to npm.

The new `npm` job authenticates over OIDC rather than a long-lived `NPM_TOKEN`:

```yaml
permissions:
  contents: read
  id-token: write
```
